### PR TITLE
Update link to Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You got 3 ways to start using this `bad-boy`:
 <br/>
 
 ## Releases - Binaries
-Head over to the [releases section](https://github.com/dfirence/mitre-assistant/releases/) and download the binary for your OS.  However, note, I am only supporting binaries for **64 bit versions** of:
+Head over to the [releases section](https://github.com/Sukelluskello/mitre-assistant/releases) and download the binary for your OS.  However, note, I am only supporting binaries for **64 bit versions** of:
 
 * MacOS
 * Debian


### PR DESCRIPTION
I've updated the link to the Releases to match the Releases section of the correct GitHub repository.  

Please also note that the project [documentation home page](https://docs-ma.vercel.app/docs/project/Brief_Overview) currently links to the [seemingly out-of-date GitHub repository](https://github.com/dfirence/mitre-assistant) and therefore returns a 404 not found error.